### PR TITLE
Support stations without peak forecast data (Issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 [![License][license-shield]](LICENSE)
 [![hacs][hacsbadge]](hacs)
 [![hacs][hacs-shield]](https://my.home-assistant.io/redirect/hacs_repository/?owner=EnlightningMan&repository=ha-bsh_tides&category=integration)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support%20me-yellow.svg?style=for-the-badge&logo=buy-me-a-coffee)](https://www.buymeacoffee.com/selbstausloeser)
 
 
 # BSH Tides for Germany Integration for Home Assistant
 
 Custom integration to fetch tidal forecast data from the German Federal Maritime and Hydrographic Agency / the Bundesamt für Seeschifffahrt und Hydrographie (BSH).
+
+For German speaking users, I've written several blog posts about this integration with more examples and details in my blog: https://www.selbstausloeser.de/tag/bsh-tides/
 
 DISCLAIMER: This project is a private open source project and doesn't have any connection with BSH. The integration utilizes a public but uncommented API of the BSH. It might break or vanish in the future.
 
@@ -22,6 +25,8 @@ Creates Home Assistant devices and sensors for multiple data points:
 
 ![BSH Sensors](images/bsh_sensors.png)
 ![BSH Diagnostic Sensors](images/bsh_diagnostic_sensors.png)
+
+If you like this project, consider buying me a coffee ☕ :) [![Buy Me A Coffee](https://buymeacoffee.com/assets/img/custom_images/yellow_img.png)](https://www.buymeacoffee.com/selbstausloeser)
 
 📡 **Data Source**
 
@@ -64,7 +69,12 @@ Then
 
 The full list of supported stations can be seen in the map overview at https://wasserstand-nordsee.bsh.de/
 
+Most of the stations support a "peak value forecast" where the BSH data contains explicit times for when the next high and low tide events will occur including their expected deviation from the mean values. Some stations, however, do not contain this explicit data. For these stations we fallback to the curve level forecast which contains a forecast of water levels in 10 minute intervals for the next few days. We find the min/max of these curves to show the best estimate for the actual time of the peak event. Note that this method is less accurate since there are small fluctuations in the water level around the peak time so, they can be +-20 minutes or so off. 
 
+To see which version the selected station supports, check the diagnostics sensor "Forecast Type" which will either be
+
+- `Peak Value Forecast` (for the accurate BSH data), or
+- `Interval Curve Forecast` (for the value extracted from the forecast curve)
 
 ## 🖼️ Visualization & Template Examples
 ![BSH Dashboard Visualization](images/bsh_mushroom_sensors.png)

--- a/custom_components/bsh_tides/coordinator.py
+++ b/custom_components/bsh_tides/coordinator.py
@@ -3,10 +3,13 @@
 from datetime import timedelta
 import logging
 
+import dateutil.parser
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .bsh_api import BshApi
+from .const import TideEvent
 from .exceptions import BshApiError
 
 _LOGGER = logging.getLogger(__name__)
@@ -17,6 +20,7 @@ class BshTidesCoordinator(DataUpdateCoordinator):
     def __init__(self, hass: HomeAssistant, bshnr: str):
         self.api = BshApi(bshnr)
         self.bshnr = bshnr
+        self._parsed_forecast_data = None
 
         super().__init__(
             hass,
@@ -35,6 +39,7 @@ class BshTidesCoordinator(DataUpdateCoordinator):
                 data.get("station_name"),
                 data.get("creation_forecast"),
             )
+            self._parse_forecast_data(data)
             return data
         except BshApiError as err:
             _LOGGER.warning("BSH API error while updating data: %s", err)
@@ -55,5 +60,121 @@ class BshTidesCoordinator(DataUpdateCoordinator):
 
     @property
     def forecast_data(self) -> list[dict]:
-        """Accessor shortcut to the forecast data."""
-        return self.data.get("hwnw_forecast", {}).get("data", [])
+        """Return the pre-parsed forecast data."""
+        return self._parsed_forecast_data
+
+    def _parse_forecast_data(self, data: dict):
+        """Parse the data from the API once for usage.
+
+        The hwnw data contains actual forecast for the next high and low tide including expected value, deviation from mean,
+        and a code for the event (HW / NW)
+        Note: The hwnw data is not avaialble for all stations.
+        Those who do not have it, need to use curve_forecast instead.
+        """
+        if "hwnw_forecast" in data:
+            forecast = data.get("hwnw_forecast", {}).get("data", [])
+            for item in forecast:
+                item["forecast"] = self.parse_forecast_value(item["forecast"])
+            self._parsed_forecast_data = forecast
+        else:
+            _LOGGER.warning(
+                "No hwnw_forecast data available for station %s, using curve_forecast instead",
+                self.bshnr,
+            )
+            self._parsed_forecast_data = self._find_curve_extrema(data)
+
+    def parse_forecast_value(self, forecast: str) -> float | None:
+        """Parse a forecast string (e.g. "+/-0,0 m", "-0,1 m", "+0,2 m") into a float value."""
+
+        if isinstance(forecast, (int, float)):
+            return forecast
+        try:
+            return round(
+                float(
+                    forecast.replace(",", ".")
+                    .replace("+/-", "")
+                    .replace("+", "")
+                    .replace(" m", "")
+                )
+                * 100.0
+            )
+        except Exception as e:
+            _LOGGER.debug("Failed to parse forecast value: %s", e)
+            return None
+
+    def _find_curve_extrema(self, data: list[dict]) -> list[dict]:
+        """Find significant local minima (NW) and maxima (HW) in curve_forecast.
+
+        We only consider extrema that are at least 45 minutes apart to avoid noise.
+        The returned list contains dictionaries with the following keys:
+        - "timestamp": The timestamp of the extremum.
+        - "value": The value of the extremum.
+        - "event": The type of event (TideEvent.HIGH or TideEvent.LOW).
+        - "forecast": The forecast value for the extremum, relative diff to MHW or MNW.
+
+        It returns the same data format as hwnw_forecast.
+        """
+        extrema = []
+        min_gap = timedelta(minutes=45)
+        last_extremum_time = None
+        last_extremum_value = None
+        last_extremum_event = None
+        curve = data.get("curve_forecast", {}).get("data", [])
+
+        for i in range(1, len(curve) - 1):
+            prev = curve[i - 1]
+            curr = curve[i]
+            nxt = curve[i + 1]
+
+            # curveforecast will only be set for future values, which is what we are looking for anyway.
+            val = curr.get("curveforecast") or None
+            prev_val = prev.get("curveforecast") or None
+            next_val = nxt.get("curveforecast") or None
+
+            if val is None or prev_val is None or next_val is None:
+                continue
+
+            is_max = prev_val < val >= next_val
+            is_min = prev_val > val <= next_val
+
+            if not (is_max or is_min):
+                continue
+
+            ts = dateutil.parser.parse(curr["timestamp"])
+
+            is_in_fluctuation_period = last_extremum_time and abs(ts - last_extremum_time) < min_gap
+
+            if is_in_fluctuation_period:
+                # in the fluctuation_period, we check if we move further into the same direction (this skips small fluctuations in the other direction)
+                # we select the new reading, iff it is a stronger extremum in the same direction
+                if last_extremum_event == TideEvent.HIGH.value and val < last_extremum_value:
+                    continue
+                if last_extremum_event == TideEvent.LOW.value and val > last_extremum_value:
+                    continue 
+
+            if is_max:
+                event = TideEvent.HIGH.value
+                forecast = val - data.get("MHW", {})
+            else:
+                event = TideEvent.LOW.value
+                forecast = val - data.get("MNW", {})
+
+            new_event = (
+                {
+                    "timestamp": curr["timestamp"],
+                    "value": val,
+                    "event": event,
+                    "forecast": forecast,
+                }
+            )
+
+            if is_in_fluctuation_period:
+                extrema[-1] = new_event
+            else:
+                extrema.append(new_event)
+
+            last_extremum_time = ts
+            last_extremum_value = val
+            last_extremum_event = event
+
+        return extrema

--- a/custom_components/bsh_tides/strings.json
+++ b/custom_components/bsh_tides/strings.json
@@ -67,6 +67,13 @@
       },
       "mean_low_water_level": {
         "name": "Mean Low Water Level"
+      },
+      "forecast_type": {
+        "name": "Forecast Type",
+        "state": {
+          "peak_value_forecast": "Peak Value Forecast",
+          "curve_forecast": "Interval Curve Forecast"
+        }
       }
     }
   }

--- a/custom_components/bsh_tides/translations/de.json
+++ b/custom_components/bsh_tides/translations/de.json
@@ -66,6 +66,13 @@
       },
       "mean_low_water_level": {
         "name": "Mittleres Niedrigwasser"
+      },
+      "forecast_type": {
+        "name": "Vorhersagentyp",
+        "state": {
+          "peak_value_forecast": "Scheitelwertvorhersage",
+          "curve_forecast": "Interval Kurvenvorhersage"
+        }
       }
     }
   }

--- a/custom_components/bsh_tides/translations/en.json
+++ b/custom_components/bsh_tides/translations/en.json
@@ -66,6 +66,13 @@
       },
       "mean_low_water_level": {
         "name": "Mean Low Water Level"
+      },
+      "forecast_type": {
+        "name": "Forecast Type",
+        "state": {
+          "peak_value_forecast": "Peak Value Forecast",
+          "curve_forecast": "Interval Curve Forecast"
+        }
       }
     }
   }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import AsyncMock, MagicMock
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.bsh_tides.coordinator import BshTidesCoordinator
@@ -16,22 +17,179 @@ def dummy_hass():
 
     return DummyHass()
 
+@pytest.fixture
+def mock_bsh_api():
+    """Mock the BSH API."""
+    # Mocking the API class, especially the async_fetch_data method
+    mock_api = MagicMock()
+    
+    return mock_api
+
+
+@pytest.fixture
+def dummy_coordinator(dummy_hass, mock_bsh_api):
+    """Create a dummy BshTidesCoordinator."""
+    coordinator = BshTidesCoordinator(hass=dummy_hass, bshnr="999X")
+    coordinator.api = mock_bsh_api  # Assign the mocked BshApi to the coordinator
+    return coordinator
+
+
+# --- Tests --- #
 
 @pytest.mark.asyncio
-async def test_coordinator_update_fails_on_api_error(monkeypatch, dummy_hass):
+async def test_coordinator_update_fails_on_api_error(mock_bsh_api, dummy_coordinator):
     """Test that coordinator raises UpdateFailed on API error."""
 
-    async def failing_fetch_data(self):
-        raise BshCannotConnect("Could not connect to BSH API")
-
-    monkeypatch.setattr(
-        "custom_components.bsh_tides.bsh_api.BshApi.async_fetch_data",
-        failing_fetch_data,
-    )
-
-    coordinator = BshTidesCoordinator(dummy_hass, bshnr="999X")
+    # Simulate that async_fetch_data will raise an error
+    mock_bsh_api.async_fetch_data = AsyncMock(side_effect=BshCannotConnect("Could not connect to BSH API"))
 
     with pytest.raises(UpdateFailed) as exc:
-        await coordinator._async_update_data()
+        await dummy_coordinator._async_update_data()
 
+    # Check if the correct error message is raised
     assert "Could not connect to BSH API" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_coordinator_parses_forecast_data(mock_bsh_api, dummy_coordinator):
+    """Test that forecast data is parsed only once."""
+
+    # Mock the API data to simulate forecast data
+    mock_bsh_api.async_fetch_data = AsyncMock(return_value={
+        "station_name": "Dummy Station",
+        "seo_id": "dummy_station",
+        "hwnw_forecast": {
+            "data": [
+                {"timestamp": "2025-07-13T12:00:00", "forecast": "+/-0,0 m"},
+                {"timestamp": "2025-07-13T14:00:00", "forecast": "-0,1 m"},
+                {"timestamp": "2025-07-13T16:00:00", "forecast": "+0,3 m"},
+            ]
+        }
+    })
+
+    # Perform the update once
+    dummy_coordinator.data = await dummy_coordinator._async_update_data()
+
+    # Check that parsed data is stored correctly
+    assert dummy_coordinator._parsed_forecast_data is not None
+    assert len(dummy_coordinator._parsed_forecast_data) == 3  # Should have 3 parsed items
+    assert dummy_coordinator.station_name == "Dummy Station"
+    assert dummy_coordinator.seo_id == "dummy_station"
+    assert dummy_coordinator.forecast_data[0]["forecast"] == 0
+    assert dummy_coordinator.forecast_data[1]["forecast"] == -10
+    assert dummy_coordinator.forecast_data[2]["forecast"] == 30
+
+@pytest.mark.asyncio
+async def test_coordinator_parses_curve_forecast(mock_bsh_api, dummy_coordinator):
+    """Test that forecast data is parsed only once."""
+
+    # Mock the API data to simulate forecast data
+    mock_bsh_api.async_fetch_data = AsyncMock(return_value={
+        "station_name": "Dummy Station",
+        "seo_id": "dummy_station",
+        "bshnr": "999X",
+        "MHW": 744,
+        "MNW": 430,
+        "curve_forecast": {
+            "data": [
+                {
+                    "timestamp": "2025-07-13 14:30:00+02:00",
+                    "astro": 475,
+                    "curveforecast": 415,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 14:40:00+02:00",
+                    "astro": 471,
+                    "curveforecast": 408,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 14:50:00+02:00",
+                    "astro": 466,
+                    "curveforecast": 400,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 15:00:00+02:00",
+                    "astro": 461,
+                    "curveforecast": 400,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 15:10:00+02:00",
+                    "astro": 457,
+                    "curveforecast": 403,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 15:20:00+02:00",
+                    "astro": 453,
+                    "curveforecast": 398,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 15:30:00+02:00",
+                    "astro": 448,
+                    "curveforecast": 395,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 15:33:00+02:00",
+                    "astro": 448,
+                    "curveforecast": 398,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 15:40:00+02:00",
+                    "astro": 453,
+                    "curveforecast": 415,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 15:50:00+02:00",
+                    "astro": 476,
+                    "curveforecast": 439,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 20:30:00+02:00",
+                    "astro": 770,
+                    "curveforecast": 780,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 20:40:00+02:00",
+                    "astro": 770,
+                    "curveforecast": 770,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 20:50:00+02:00",
+                    "astro": 770,
+                    "curveforecast": 784,
+                    "measurement": None
+                },
+                {
+                    "timestamp": "2025-07-13 20:51:00+02:00",
+                    "astro": 770,
+                    "curveforecast": 770,
+                    "measurement": None
+                },
+            ]
+        }
+    })
+
+    # Perform the update once
+    dummy_coordinator.data = await dummy_coordinator._async_update_data()
+
+    # Check that parsed data is stored correctly
+    assert dummy_coordinator._parsed_forecast_data is not None
+    assert len(dummy_coordinator._parsed_forecast_data) == 2  # Should have 1 parsed item
+    assert dummy_coordinator.station_name == "Dummy Station"
+    assert dummy_coordinator.seo_id == "dummy_station"
+    # check the low tide event
+    assert dummy_coordinator.forecast_data[0]["timestamp"] == "2025-07-13 15:30:00+02:00"
+    assert dummy_coordinator.forecast_data[0]["forecast"] == -35
+    # check the high tide event
+    assert dummy_coordinator.forecast_data[1]["timestamp"] == "2025-07-13 20:50:00+02:00"
+    assert dummy_coordinator.forecast_data[1]["forecast"] == 40


### PR DESCRIPTION
Not all stations available through the API contain the peak value forecasts (Scheitelwertvorhersage) in their API data. Those which do not only contain interval based water level curve forecasts.

Provide fallback to find the min/max values in the curve forecasts to estimate the time and height of the peak water levels for low & high tide events.

Add diagnostic sensor reporting which type of forecast is being used for the station.