### PR TITLE
Migrate to the official gdi.bsh.de OGC API (fixes #5)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -m pytest)",
+      "Bash(gh issue *)",
+      "WebFetch(domain:github.com)",
+      "Bash(curl -sL -m 20 \"https://wasserstand.bsh.de/\" -w \"\\\\nHTTP %{http_code}\\\\n\" -o /tmp/new_root.html)",
+      "Read(//tmp/**)",
+      "Bash(curl -sL -m 30 \"https://gdi.bsh.de/ldproxy/rest/services/WaterLevelForecast?lang=en\" -w \"\\\\nHTTP %{http_code} ct=%{content_type}\\\\n\" -o /tmp/ld_root.json)",
+      "Bash(curl -sL -m 30 \"https://gdi.bsh.de/ldproxy/rest/services/WaterLevelForecast/collections?lang=en&f=json\" -o /tmp/ld_coll.json -w \"HTTP %{http_code}\\\\n\")",
+      "Bash(python3 -c \"import json;d=json.load\\(open\\('/tmp/ld_coll.json'\\)\\);print\\([c['id'] for c in d.get\\('collections',[]\\)]\\);[print\\(c['id'],'-',c.get\\('title'\\)\\) for c in d.get\\('collections',[]\\)]\")",
+      "Bash(curl -fsSL https://claude.com/install.sh)",
+      "Bash(bash)",
+      "Bash(curl -fsSL https://claude.ai/install.sh)"
+    ]
+  }
+}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
 	"name": "bsh_tides_devcontainer",
 	"image": "mcr.microsoft.com/devcontainers/python:3.12",
 	"features": {
-	  "ghcr.io/devcontainers/features/github-cli:1": {}
+	  "ghcr.io/devcontainers/features/node:1": {},
+	  "ghcr.io/devcontainers/features/github-cli:1": {},
+	  "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
 	},
 	"customizations": {
 	  "vscode": {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Custom integration to fetch tidal forecast data from the German Federal Maritime
 
 For German speaking users, I've written several blog posts about this integration with more examples and details in my blog: https://www.selbstausloeser.de/tag/bsh-tides/
 
-DISCLAIMER: This project is a private open source project and doesn't have any connection with BSH. The integration utilizes a public but uncommented API of the BSH. It might break or vanish in the future.
+DISCLAIMER: This project is a private open source project and doesn't have any connection with BSH. The integration utilizes the BSH's official, documented water level forecast API ([gdi.bsh.de OGC API Features](https://gdi.bsh.de/ldproxy/rest/services/WaterLevelForecast?lang=en)), whose data is provided free of charge under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). It might still change or vanish in the future.
 
 🌊 **Features**
 
@@ -30,16 +30,11 @@ If you like this project, consider buying me a coffee ☕ :) [![Buy Me A Coffee]
 
 📡 **Data Source**
 
-The [BSH Tide Data](https://wasserstand-nordsee.bsh.de/) provides tide data for the German North Sea costal region including measuring points for tide affected rivers: 
-- Ems, 
-- Weser,
-- Elbe,
-- Jade und Ostfriesland,
-- Nordfriesland bis Elbmündung (inkl. Helgoland)
+The integration uses the BSH's official [Water Level Forecast OGC API](https://gdi.bsh.de/ldproxy/rest/services/WaterLevelForecast?lang=en). It provides forecast data for both the German **North Sea** coastal region (including tide-affected rivers such as the Ems, Weser, Elbe, Jade und Ostfriesland, Nordfriesland bis Elbmündung) **and the Baltic Sea** (e.g. Kieler Bucht, Lübecker Bucht, Westlich/Östlich Rügens, Kleines Haff).
 
-Check [link](https://wasserstand-nordsee.bsh.de/) for supported gauging stations.
+Check the [BSH water level map](https://wasserstand.bsh.de/) for the supported gauging stations.
 
-Data © Bundesamt für Seeschifffahrt und Hydrographie (BSH)
+Data © Bundesamt für Seeschifffahrt und Hydrographie (BSH), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## 🔧 Installation
 
@@ -67,7 +62,7 @@ Then
 
 ## 📍 Supported Stations
 
-The full list of supported stations can be seen in the map overview at https://wasserstand-nordsee.bsh.de/
+The full list of supported stations can be seen in the map overview at https://wasserstand.bsh.de/
 
 Most of the stations support a "peak value forecast" where the BSH data contains explicit times for when the next high and low tide events will occur including their expected deviation from the mean values. Some stations, however, do not contain this explicit data. For these stations we fallback to the curve level forecast which contains a forecast of water levels in 10 minute intervals for the next few days. We find the min/max of these curves to show the best estimate for the actual time of the peak event. Note that this method is less accurate since there are small fluctuations in the water level around the peak time so, they can be +-20 minutes or so off. 
 
@@ -91,17 +86,8 @@ You can copy these into your dashboard using the YAML editor.
 
 ## 📄 License & Attribution
 
-- Data: © BSH – Bundesamt für Seeschifffahrt und Hydrographie  
+- Data: © BSH – Bundesamt für Seeschifffahrt und Hydrographie, licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
 - Integration: MIT License
-
-## 🔐 Note on SSL Certificate Verification
-
-> This integration **disables strict SSL certificate validation** when connecting to the BSH tide API.
-
-While the connection is still **secure and encrypted using HTTPS**, the integration does **not validate the certificate authority (CA)**.  
-This is necessary because the BSH server sometimes presents a certificate chain that fails verification on some systems, including Home Assistant installations and Docker containers.
-
-⚠️ **If you are concerned about this behavior**, you can review the certificate chain manually via [https://wasserstand-nordsee.bsh.de/](https://wasserstand-nordsee.bsh.de/).
 
 [hacs]: https://github.com/custom-components/hacs
 [hacs-shield]: https://img.shields.io/badge/HACS-Install%20via%20HACS-orange?style=for-the-badge&logo=home-assistant

--- a/custom_components/bsh_tides/__init__.py
+++ b/custom_components/bsh_tides/__init__.py
@@ -10,54 +10,20 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import BshTidesCoordinator
-from .bsh_api import BshApi
+
+# TEMPORARY: one-time v1 (bshnr) -> v2 (slug) migration for the 2026-05 API
+# switch. Home Assistant picks up ``async_migrate_entry`` from this module via
+# the re-export below. Both the import and the ``legacy_migration`` package can
+# be deleted once no pre-v2 config entries remain (see that package's docstring).
+from .legacy_migration import async_migrate_entry
 
 _LOGGER = logging.getLogger(__name__)
 
+# Re-exported so Home Assistant discovers the migration hook on this module.
+__all__ = ["async_migrate_entry", "async_setup_entry", "async_unload_entry"]
+
 # BSH Api Response gets put into a sensor
 _PLATFORMS: list[Platform] = [Platform.SENSOR]
-
-
-async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate old config entries to the new gdi.bsh.de OGC API.
-
-    v1 stored the old BSH "bshnr" (e.g. "111P"). The new API addresses stations
-    by slug (e.g. "norderney_riffgat"). The new API does not expose the old
-    bshnr, so we map by station name (the entry title) against the new station
-    list. The slug equals the existing seo_id, so entity unique_ids are kept and
-    the user's history/automations survive the migration untouched.
-    """
-    if entry.version == 1:
-        old_key = entry.data.get("bshnr")
-        try:
-            stations = await BshApi.fetch_station_list()
-        except Exception as err:  # noqa: BLE001 - transient: let HA retry later
-            _LOGGER.warning("BSH migration deferred (station list unavailable): %s", err)
-            return False
-
-        title = (entry.title or "").strip().casefold()
-        slug = next(
-            (sid for sid, name, _ in stations if name.strip().casefold() == title),
-            None,
-        )
-        if slug is None:
-            # Maybe the stored key already is a valid slug.
-            slug = next((sid for sid, _, _ in stations if sid == old_key), None)
-        if slug is None:
-            _LOGGER.error(
-                "Could not migrate BSH station '%s' (title '%s') to the new API. "
-                "Please remove and re-add the integration.",
-                old_key,
-                entry.title,
-            )
-            return False
-
-        hass.config_entries.async_update_entry(
-            entry, data={**entry.data, "bshnr": slug}, version=2
-        )
-        _LOGGER.info("Migrated BSH station '%s' -> slug '%s'", old_key, slug)
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/bsh_tides/__init__.py
+++ b/custom_components/bsh_tides/__init__.py
@@ -10,11 +10,54 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import BshTidesCoordinator
+from .bsh_api import BshApi
 
 _LOGGER = logging.getLogger(__name__)
 
 # BSH Api Response gets put into a sensor
 _PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old config entries to the new gdi.bsh.de OGC API.
+
+    v1 stored the old BSH "bshnr" (e.g. "111P"). The new API addresses stations
+    by slug (e.g. "norderney_riffgat"). The new API does not expose the old
+    bshnr, so we map by station name (the entry title) against the new station
+    list. The slug equals the existing seo_id, so entity unique_ids are kept and
+    the user's history/automations survive the migration untouched.
+    """
+    if entry.version == 1:
+        old_key = entry.data.get("bshnr")
+        try:
+            stations = await BshApi.fetch_station_list()
+        except Exception as err:  # noqa: BLE001 - transient: let HA retry later
+            _LOGGER.warning("BSH migration deferred (station list unavailable): %s", err)
+            return False
+
+        title = (entry.title or "").strip().casefold()
+        slug = next(
+            (sid for sid, name, _ in stations if name.strip().casefold() == title),
+            None,
+        )
+        if slug is None:
+            # Maybe the stored key already is a valid slug.
+            slug = next((sid for sid, _, _ in stations if sid == old_key), None)
+        if slug is None:
+            _LOGGER.error(
+                "Could not migrate BSH station '%s' (title '%s') to the new API. "
+                "Please remove and re-add the integration.",
+                old_key,
+                entry.title,
+            )
+            return False
+
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "bshnr": slug}, version=2
+        )
+        _LOGGER.info("Migrated BSH station '%s' -> slug '%s'", old_key, slug)
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/bsh_tides/bsh_api.py
+++ b/custom_components/bsh_tides/bsh_api.py
@@ -128,9 +128,7 @@ class BshApi:
         """Fetch and normalise tide data for a single station."""
         try:
             async with aiohttp.ClientSession() as session:
-                # ssl=False kept on purpose: BSH has historically served a
-                # certificate chain that fails to validate inside HAOS/Docker.
-                async with session.get(self.api_url, ssl=False) as response:
+                async with session.get(self.api_url) as response:
                     response.raise_for_status()
                     feature = await response.json(content_type=None)
         except aiohttp.ClientError as e:
@@ -155,7 +153,7 @@ class BshApi:
         try:
             async with aiohttp.ClientSession() as session:
                 for _ in range(_MAX_PAGES):
-                    async with session.get(url, ssl=False) as response:
+                    async with session.get(url) as response:
                         response.raise_for_status()
                         payload = await response.json(content_type=None)
 

--- a/custom_components/bsh_tides/bsh_api.py
+++ b/custom_components/bsh_tides/bsh_api.py
@@ -1,31 +1,138 @@
-import aiohttp
+"""Client for the BSH water level forecast OGC API (gdi.bsh.de).
+
+In May 2026 the BSH retired the old, undocumented JSON endpoint at
+``wasserstand-nordsee.bsh.de/data/*.json`` and replaced it with an official,
+documented OGC API Features service (ldproxy) under ``gdi.bsh.de``. The data is
+provided free of charge under CC BY 4.0.
+
+This module talks to the new API and translates each station Feature back into
+the flat dict structure that the coordinator/sensors already expect, so the
+rest of the integration stays unchanged.
+
+Station "ids" are slugs (e.g. ``norderney_riffgat``). For historical reasons
+the slug is still stored under the config key ``bshnr``.
+"""
+
 import logging
+
+import aiohttp
 
 from .exceptions import BshApiError, BshCannotConnect, BshInvalidStation
 
 _LOGGER = logging.getLogger(__name__)
 
+API_BASE = (
+    "https://gdi.bsh.de/ldproxy/rest/services/WaterLevelForecast"
+    "/collections/waterlevelforecastdata/items"
+)
+# Page size for the station list. The service currently lists ~135 stations;
+# we still follow "next" links below to stay correct if that grows.
+_LIST_LIMIT = 1000
+_MAX_PAGES = 20
+
+
+def _num(value):
+    """Parse a BSH numeric field (often a string like "594") into a number."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+
+def feature_to_legacy(feature: dict) -> dict:
+    """Translate a WaterLevelForecast Feature into the legacy data dict.
+
+    Keys consumed downstream: station_name, seo_id, area, creation_forecast,
+    MHW, MNW, copyright_note, and either hwnw_forecast{data[]} (peak forecast)
+    or curve_forecast{data[]} (curve fallback).
+    """
+    if not isinstance(feature, dict) or "properties" not in feature:
+        raise BshInvalidStation(f"Unexpected feature payload: {feature!r}")
+
+    props = feature["properties"]
+
+    copyright_note = "© BSH – Bundesamt für Seeschifffahrt und Hydrographie"
+    cr = props.get("copyright")
+    if isinstance(cr, dict):
+        copyright_note = cr.get("de") or cr.get("en") or copyright_note
+    elif isinstance(cr, str):
+        copyright_note = cr
+
+    data: dict = {
+        "station_name": props.get("gauge_label"),
+        "seo_id": feature.get("id"),
+        "area": props.get("area"),
+        "creation_forecast": (
+            props.get("forecast_timestamp")
+            or props.get("automated_curveforecast_timestamp")
+        ),
+        "MHW": _num(props.get("mean_high_water")),
+        "MNW": _num(props.get("mean_low_water")),
+        "copyright_note": copyright_note,
+    }
+
+    # Primary path: explicit high/low water peak predictions.
+    hwnw = props.get("high_water_low_water")
+    if isinstance(hwnw, list) and hwnw:
+        forecast = []
+        for ev in hwnw:
+            value = ev.get("forecast_value")
+            if value is None:
+                value = ev.get("tidal_prediction_value")
+            forecast.append(
+                {
+                    "timestamp": ev.get("event_timestamp"),
+                    "event": ev.get("event"),  # "HW" / "NW"
+                    "value": _num(value),
+                    # kept as the original "-0,3 m" string; the coordinator
+                    # parses it via parse_forecast_value().
+                    "forecast": ev.get("forecast_deviation"),
+                }
+            )
+        data["hwnw_forecast"] = {"data": forecast}
+    else:
+        # Fallback: derive extrema from the model curve. The coordinator's
+        # _find_curve_extrema() expects items with "timestamp" + "curveforecast".
+        curve = props.get("curve")
+        curve_data = []
+        if isinstance(curve, list):
+            for point in curve:
+                curve_data.append(
+                    {
+                        "timestamp": point.get("timestamp"),
+                        "curveforecast": _num(point.get("automated_curve_forecast")),
+                    }
+                )
+        data["curve_forecast"] = {"data": curve_data}
+
+    return data
+
 
 class BshApi:
-    """Class for interacting with the BSH Tides API."""
+    """Class for interacting with the BSH water level forecast API."""
 
-    # Contains the list of available stations
-    MAP_URL = "https://wasserstand-nordsee.bsh.de/data/map.json"
+    def __init__(self, station_id: str):
+        # Historically called bshnr; now holds the station slug.
+        self.bshnr = station_id
+        self.station_id = station_id
+        self.api_url = f"{API_BASE}/{station_id}?f=json"
 
-    def __init__(self, bshnr: str):
-        self.bshnr = bshnr
-        self.api_url = f"https://wasserstand-nordsee.bsh.de/data/DE__{bshnr}.json"
-
-    async def async_fetch_data(self):
-        """Fetch tide data for a given station."""
+    async def async_fetch_data(self) -> dict:
+        """Fetch and normalise tide data for a single station."""
         try:
             async with aiohttp.ClientSession() as session:
+                # ssl=False kept on purpose: BSH has historically served a
+                # certificate chain that fails to validate inside HAOS/Docker.
                 async with session.get(self.api_url, ssl=False) as response:
                     response.raise_for_status()
-                    data = await response.json()
-                    if "station_name" not in data or "gauges" in data:
-                        raise BshInvalidStation(f"Invalid station data: {data}")
-                    return data
+                    feature = await response.json(content_type=None)
         except aiohttp.ClientError as e:
             _LOGGER.debug("aiohttp.ClientError: %s", e)
             raise BshCannotConnect("Could not connect to BSH API") from e
@@ -33,23 +140,53 @@ class BshApi:
             _LOGGER.debug("Invalid JSON in station data: %s", e)
             raise BshApiError("Invalid JSON in response") from e
 
+        if not isinstance(feature, dict) or feature.get("type") != "Feature":
+            raise BshInvalidStation(f"Invalid station data: {feature}")
+
+        return feature_to_legacy(feature)
+
     @staticmethod
     async def fetch_station_list() -> list[tuple[str, str, str]]:
-        """Fetch all available stations with (bshnr, station_name, area) for config_flow."""
+        """Fetch all stations as (slug, station_name, area) for the config flow."""
+        # Only request the properties we need for the dropdown to keep the
+        # payload small (ldproxy honours `properties`; ignored gracefully if not).
+        url = f"{API_BASE}?f=json&limit={_LIST_LIMIT}"
+        stations: list[tuple[str, str, str]] = []
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get(BshApi.MAP_URL, ssl=False) as response:
-                    response.raise_for_status()
-                    data = await response.json()
-                    if "gauges" not in data:
-                        raise BshInvalidStation("Missing 'gauges' in station list")
-                    return [
-                        (entry["bshnr"], entry["station_name"], entry["area"])
-                        for entry in data["gauges"]
-                    ]
+                for _ in range(_MAX_PAGES):
+                    async with session.get(url, ssl=False) as response:
+                        response.raise_for_status()
+                        payload = await response.json(content_type=None)
+
+                    features = payload.get("features")
+                    if not isinstance(features, list):
+                        raise BshInvalidStation("Missing 'features' in station list")
+
+                    for feat in features:
+                        props = feat.get("properties", {}) or {}
+                        slug = feat.get("id")
+                        name = props.get("gauge_label")
+                        area = props.get("area")
+                        if slug and name and area:
+                            stations.append((slug, name, area))
+
+                    # Follow OGC API "next" link if the result was paginated.
+                    next_url = None
+                    for link in payload.get("links", []) or []:
+                        if link.get("rel") == "next" and link.get("href"):
+                            next_url = link["href"]
+                            break
+                    if not next_url:
+                        break
+                    url = next_url
         except aiohttp.ClientError as e:
             _LOGGER.debug("aiohttp.ClientError while fetching station list: %s", e)
             raise BshCannotConnect("Could not connect to BSH station list API") from e
         except (ValueError, KeyError) as e:
             _LOGGER.debug("Invalid station list data: %s", e)
             raise BshApiError("Invalid data in station list response") from e
+
+        if not stations:
+            raise BshInvalidStation("Empty station list")
+        return stations

--- a/custom_components/bsh_tides/config_flow.py
+++ b/custom_components/bsh_tides/config_flow.py
@@ -31,7 +31,9 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 class BshTidesConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for BSH Tides for Germany."""
 
-    VERSION = 1
+    # v2: migrated from the retired wasserstand-nordsee.bsh.de JSON endpoint
+    # (bshnr keys like "111P") to the gdi.bsh.de OGC API (station slugs).
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/bsh_tides/legacy_migration/__init__.py
+++ b/custom_components/bsh_tides/legacy_migration/__init__.py
@@ -1,0 +1,176 @@
+"""TEMPORARY config-entry migration: old BSH ``bshnr`` keys -> station slugs.
+
+In May 2026 the BSH retired the undocumented ``wasserstand-nordsee.bsh.de``
+endpoint (which addressed stations by ``bshnr``, e.g. ``111P``) in favour of
+the official gdi.bsh.de OGC API (which uses slugs, e.g. ``norderney_riffgat``).
+Config entries created by integration versions < 0.1.0 still store the old
+``bshnr`` under the ``data["bshnr"]`` key, so they must be migrated to the slug.
+
+This whole package exists only to carry users across that one-time switch and
+is intentionally isolated from the runtime code so it can be deleted cleanly.
+
+--------------------------------------------------------------------------------
+REMOVAL — safe to delete this entire ``legacy_migration`` package once no
+installs run config entries below schema version 2 anymore. Practically: from
+~mid-2027 (about a year after the 0.1.0 release that introduced it), enough
+update cycles will have passed that every active install has migrated.
+
+To remove:
+  * delete the ``legacy_migration/`` folder, and
+  * drop the ``from .legacy_migration import async_migrate_entry`` re-export in
+    ``custom_components/bsh_tides/__init__.py``.
+Home Assistant only calls ``async_migrate_entry`` for entries whose version is
+below the config-flow ``VERSION`` (2); with none left, the hook is dead code.
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from ..bsh_api import BshApi
+from ..const import DOMAIN
+from .station_map import LEGACY_BSHNR_TO_SLUG
+
+_LOGGER = logging.getLogger(__name__)
+
+# Entity unique_ids are "bsh_{seo_id}_{translation_key}". To recover the seo_id
+# (which equals the new station slug) we strip the "bsh_" prefix and a known
+# translation-key suffix. Listed longest-first so we never strip a shorter key
+# that happens to be a tail of a longer one. Keep in sync with sensor.py.
+_UNIQUE_ID_SUFFIXES: tuple[str, ...] = tuple(
+    sorted(
+        (
+            "next_tide_time",
+            "next_high_tide_time",
+            "next_low_tide_time",
+            "next_tide_level",
+            "next_high_tide_level",
+            "next_low_tide_level",
+            "next_tide_diff",
+            "next_high_tide_diff",
+            "next_low_tide_diff",
+            "next_tide_event",
+            "mean_high_water_level",
+            "mean_low_water_level",
+            "forecast_created_at",
+            "station_area",
+            "forecast_type",
+        ),
+        key=len,
+        reverse=True,
+    )
+)
+
+
+def _seo_id_from_unique_id(unique_id: str | None) -> str | None:
+    """Extract the seo_id (== new slug) from an entity unique_id.
+
+    "bsh_hamburg_st-pauli_next_high_tide_time" -> "hamburg_st-pauli".
+    """
+    if not unique_id or not unique_id.startswith("bsh_"):
+        return None
+    body = unique_id[len("bsh_") :]
+    for suffix in _UNIQUE_ID_SUFFIXES:
+        if body.endswith("_" + suffix):
+            return body[: -(len(suffix) + 1)]
+    return None
+
+
+def _slug_from_entity_registry(hass: HomeAssistant, entry_id: str) -> str | None:
+    """Recover the station slug from this entry's existing entities.
+
+    Offline and rename-proof: the entity unique_ids were derived from the old
+    seo_id, which is identical to the new slug.
+    """
+    ent_reg = er.async_get(hass)
+    for ent in er.async_entries_for_config_entry(ent_reg, entry_id):
+        seo_id = _seo_id_from_unique_id(ent.unique_id)
+        if seo_id:
+            return seo_id
+    return None
+
+
+def _migrate_device_identifier(hass: HomeAssistant, old_key: str, slug: str) -> None:
+    """Re-point the existing device from the old bshnr to the new slug.
+
+    The device identifier is (DOMAIN, bshnr); after migration the coordinator
+    reports (DOMAIN, slug). Updating the identifier in place keeps the user's
+    device-level customisations (area, name) and avoids leaving an orphan.
+    """
+    if old_key == slug:
+        return
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, old_key)})
+    if device is None:
+        return
+    dev_reg.async_update_device(device.id, new_identifiers={(DOMAIN, slug)})
+    _LOGGER.debug("Re-pointed device %s identifier %s -> %s", device.id, old_key, slug)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old config entries to the new gdi.bsh.de OGC API.
+
+    v1 stored the old BSH "bshnr" (e.g. "111P"). The new API addresses stations
+    by slug (e.g. "norderney_riffgat") and does not expose the old bshnr, so we
+    resolve the slug deterministically, preferring rename-proof/offline sources:
+
+      1. the seo_id encoded in this entry's existing entity unique_ids,
+      2. a static bshnr -> slug table of every station the old API served,
+      3. matching the entry title against the live station list (last resort).
+
+    The slug equals the old seo_id, so entity unique_ids are preserved and the
+    user's history/automations survive untouched.
+    """
+    if entry.version > 1:
+        return True
+
+    old_key = entry.data.get("bshnr")
+
+    # 1) Rename-proof + offline: derive slug from existing entities.
+    slug = _slug_from_entity_registry(hass, entry.entry_id)
+
+    # 2) Rename-proof + offline: static lookup of the retired bshnr.
+    if slug is None:
+        slug = LEGACY_BSHNR_TO_SLUG.get(old_key)
+
+    # 3) Last resort: match the entry title against the live station list. This
+    #    needs the network, so failures here are treated as transient (retry).
+    if slug is None:
+        try:
+            stations = await BshApi.fetch_station_list()
+        except Exception as err:  # noqa: BLE001 - transient: let HA retry later
+            _LOGGER.warning(
+                "BSH migration deferred (station list unavailable): %s", err
+            )
+            return False
+
+        title = (entry.title or "").strip().casefold()
+        slug = next(
+            (sid for sid, name, _ in stations if name.strip().casefold() == title),
+            None,
+        )
+        if slug is None:
+            # Maybe the stored key already is a valid slug.
+            slug = next((sid for sid, _, _ in stations if sid == old_key), None)
+
+    if slug is None:
+        _LOGGER.error(
+            "Could not migrate BSH station '%s' (title '%s') to the new API. "
+            "Please remove and re-add the integration.",
+            old_key,
+            entry.title,
+        )
+        return False
+
+    _migrate_device_identifier(hass, old_key, slug)
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, "bshnr": slug}, version=2
+    )
+    _LOGGER.info("Migrated BSH station '%s' -> slug '%s'", old_key, slug)
+
+    return True

--- a/custom_components/bsh_tides/legacy_migration/station_map.py
+++ b/custom_components/bsh_tides/legacy_migration/station_map.py
@@ -1,0 +1,107 @@
+"""Static legacy ``bshnr`` -> station slug mapping for config-entry migration.
+
+Until 2026-05 the integration addressed stations by the BSH "bshnr" (e.g.
+``111P``), stored in each config entry under the key ``bshnr``. The new
+gdi.bsh.de OGC API addresses stations by slug (e.g. ``norderney_riffgat``)
+and does **not** expose the old bshnr anywhere, so it cannot be derived at
+runtime.
+
+This table maps every bshnr that the retired ``wasserstand-nordsee.bsh.de``
+API ever served to its slug. The slug is identical to the old ``seo_id``,
+which means a migrated entry keeps the same entity ``unique_id``s
+(``bsh_{seo_id}_{key}``) and the user's history/automations survive.
+
+Source: archived ``wasserstand-nordsee.bsh.de/data/map.json`` (snapshot
+2025-10-05). Used as an offline, rename-proof fallback by
+``async_migrate_entry`` in this ``legacy_migration`` package.
+
+TEMPORARY: part of the v1 -> v2 migration; see ``legacy_migration/__init__.py``
+for the removal conditions.
+"""
+
+from __future__ import annotations
+
+LEGACY_BSHNR_TO_SLUG: dict[str, str] = {
+    '101P': 'borkum_fischerbalje',
+    '103P': 'bremerhaven_alter_leuchtturm',
+    '111P': 'norderney_riffgat',
+    '502P': 'bremen_oslebshausen',
+    '504B': 'brunsbuettel_ost',
+    '505P': 'buesum_schleuse',
+    '506P': 'cuxhaven_steubenhoeft',
+    '507P': 'emden_grosse_seeschleuse',
+    '508P': 'hamburg_st-pauli',
+    '509A': 'helgoland_binnenhafen',
+    '510P': 'husum_schleuse',
+    '512P': 'wilhelmshaven_alter_vorhafen',
+    '617P': 'list_hafen',
+    '618P': 'munkmarsch',
+    '620P': 'westerland',
+    '622P': 'amrum_odde',
+    '624P': 'hoernum_hafen',
+    '628A': 'osterley',
+    '629B': 'foehrer_ley_nord',
+    '631P': 'wittduen_hafen',
+    '632P': 'wyk',
+    '635P': 'dagebuell',
+    '636F': 'hooge_anleger',
+    '637A': 'der_strand_hamburger_hallig',
+    '637P': 'groede_anleger',
+    '638P': 'schluettsiel',
+    '642E': 'pellworm_hoogerfaehre',
+    '645P': 'suederoogsand',
+    '647A': 'pellworm_anleger',
+    '649P': 'strucklahnungshoern',
+    '664P': 'eider-sperrwerk_aussenpegel',
+    '667B': 'meldorf_sperrwerk_aussenpegel',
+    '677C': 'scharhoernriff_bake_a',
+    '677P': 'scharhoern_bake_c',
+    '678W': 'neuwerk_anleger',
+    '681P': 'otterndorf',
+    '683P': 'belum',
+    '688P': 'brokdorf',
+    '690P': 'stoer-sperrwerk_aussenpegel',
+    '695P': 'glueckstadt',
+    '698P': 'kollmar_kamperreihe',
+    '700R': 'krueckau-sperrwerk_binnenpegel',
+    '703P': 'grauerort',
+    '704R': 'pinnau-sperrwerk_binnenpegel',
+    '709P': 'stadersand',
+    '711P': 'hetlingen',
+    '714P': 'schulau',
+    '715P': 'hamburg_blankenese',
+    '717P': 'hamburg_cranz',
+    '720P': 'hamburg_seemannshoeft',
+    '724P': 'hamburg_harburg',
+    '727P': 'hamburg_dove-elbe_einfahrt',
+    '731P': 'hamburg_zollenspieker',
+    '732D': 'geesthacht_wehr_unterpegel',
+    '734P': 'alte_weser_leuchtturm',
+    '735A': 'spieka_neufeld',
+    '737P': 'dwarsgat',
+    '741A': 'nordenham',
+    '741B': 'rechtenfleth',
+    '743P': 'brake',
+    '744A': 'elsfleth_ohrt',
+    '744P': 'elsfleth',
+    '748P': 'oldenburg_drielake',
+    '749P': 'bremen_farge',
+    '750P': 'bremen_vegesack',
+    '751P': 'bremen_wilhelm-kaisen-bruecke',
+    '754P': 'wangerooge_nord',
+    '756P': 'wangerooge_ost',
+    '761P': 'schillig',
+    '764B': 'hooksielplate',
+    '768P': 'jade-weser-port',
+    '770P': 'wilhelmshaven_neuer_vorhafen_seeschleuse',
+    '777P': 'wangerooge_hafen',
+    '778P': 'harlesiel',
+    '779P': 'spiekeroog',
+    '781P': 'langeoog_hafeneinfahrt',
+    '782P': 'bensersiel',
+    '796C': 'leyhoern_leybucht',
+    '802P': 'knock',
+    '806P': 'leerort',
+    '808A': 'leda-sperrwerk_unterpegel',
+    '814P': 'papenburg',
+}

--- a/custom_components/bsh_tides/manifest.json
+++ b/custom_components/bsh_tides/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/EnlightningMan/ha-bsh_tides/issues",
   "iot_class": "cloud_polling",
   "requirements": ["aiohttp>=3.11.0"],
-  "version": "0.0.3"
+  "version": "0.1.0"
 }

--- a/tests/test_bsh_api.py
+++ b/tests/test_bsh_api.py
@@ -1,0 +1,125 @@
+"""Tests for the gdi.bsh.de OGC API translation layer (feature_to_legacy)."""
+
+import pytest
+
+from custom_components.bsh_tides.bsh_api import feature_to_legacy
+from custom_components.bsh_tides.exceptions import BshInvalidStation
+
+
+def _peak_feature():
+    """A Feature that carries explicit high/low water predictions."""
+    return {
+        "type": "Feature",
+        "id": "alte_weser_leuchtturm",
+        "properties": {
+            "gauge_label": "Alte Weser, Leuchtturm",
+            "area": "Jade und Ostfriesland",
+            "forecast_timestamp": "2026-06-02 07:27:55+02:00",
+            "automated_curveforecast_timestamp": "2026-06-02 11:56:22+02:00",
+            "mean_high_water": 641.0,
+            "mean_low_water": 358.0,
+            "copyright": {"de": "@BSH (de)", "en": "@BSH (en)"},
+            "high_water_low_water": [
+                {
+                    "event_timestamp": "2026-06-02 08:24:00+02:00",
+                    "event": "NW",
+                    "tidal_prediction_value": "339",
+                    "forecast_value": 338,
+                    "forecast_deviation": "-0,2 m",
+                },
+                {
+                    "event_timestamp": "2026-06-02 14:14:00+02:00",
+                    "event": "HW",
+                    # no forecast_value -> must fall back to tidal_prediction_value
+                    "forecast_value": None,
+                    "tidal_prediction_value": "652",
+                    "forecast_deviation": "+0,1 m",
+                },
+            ],
+            # present but must be ignored because peak data exists
+            "curve": [{"timestamp": "x", "automated_curve_forecast": "1"}],
+        },
+    }
+
+
+def _curve_feature():
+    """A Feature without peak data, only a model curve (fallback path)."""
+    return {
+        "type": "Feature",
+        "id": "flensburg",
+        "properties": {
+            "gauge_label": "Flensburg",
+            "area": "Kieler Bucht",
+            "forecast_timestamp": None,
+            "automated_curveforecast_timestamp": "2026-06-02 11:56:22+02:00",
+            "mean_high_water": 633.0,
+            "mean_low_water": 379.0,
+            "copyright": "@plain string copyright",
+            "high_water_low_water": [],  # empty -> curve fallback
+            "curve": [
+                # past point: no forecast field -> curveforecast None
+                {"timestamp": "2026-06-02 10:00:00+02:00", "measurement": "500"},
+                # future points carry automated_curve_forecast
+                {
+                    "timestamp": "2026-06-02 11:45:00+02:00",
+                    "automated_curve_forecast": "504",
+                },
+            ],
+        },
+    }
+
+
+def test_feature_to_legacy_peak_path():
+    data = feature_to_legacy(_peak_feature())
+
+    assert data["station_name"] == "Alte Weser, Leuchtturm"
+    assert data["seo_id"] == "alte_weser_leuchtturm"
+    assert data["area"] == "Jade und Ostfriesland"
+    assert data["creation_forecast"] == "2026-06-02 07:27:55+02:00"
+    assert data["MHW"] == 641.0
+    assert data["MNW"] == 358.0
+    assert data["copyright_note"] == "@BSH (de)"
+
+    # peak path populates hwnw_forecast and NOT curve_forecast
+    assert "hwnw_forecast" in data
+    assert "curve_forecast" not in data
+
+    events = data["hwnw_forecast"]["data"]
+    assert len(events) == 2
+
+    nw = events[0]
+    assert nw["timestamp"] == "2026-06-02 08:24:00+02:00"
+    assert nw["event"] == "NW"
+    assert nw["value"] == 338  # forecast_value
+    # raw deviation string kept; the coordinator parses it later
+    assert nw["forecast"] == "-0,2 m"
+
+    hw = events[1]
+    assert hw["event"] == "HW"
+    assert hw["value"] == 652  # fell back to tidal_prediction_value
+    assert hw["forecast"] == "+0,1 m"
+
+
+def test_feature_to_legacy_curve_path():
+    data = feature_to_legacy(_curve_feature())
+
+    assert data["seo_id"] == "flensburg"
+    assert data["copyright_note"] == "@plain string copyright"
+    # no peak data -> falls back to the curve and uses the curve timestamp
+    assert "hwnw_forecast" not in data
+    assert "curve_forecast" in data
+    assert data["creation_forecast"] == "2026-06-02 11:56:22+02:00"
+
+    points = data["curve_forecast"]["data"]
+    assert len(points) == 2
+    # past point has no forecast value
+    assert points[0]["timestamp"] == "2026-06-02 10:00:00+02:00"
+    assert points[0]["curveforecast"] is None
+    # future point maps automated_curve_forecast -> curveforecast (as number)
+    assert points[1]["curveforecast"] == 504
+
+
+@pytest.mark.parametrize("bad", [None, 42, "string", {}, {"id": "x"}])
+def test_feature_to_legacy_invalid_payload(bad):
+    with pytest.raises(BshInvalidStation):
+        feature_to_legacy(bad)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,209 @@
+"""Tests for config-entry migration to the gdi.bsh.de OGC API (v1 -> v2)."""
+
+import pytest
+
+import custom_components.bsh_tides.legacy_migration as migration
+from custom_components.bsh_tides import async_migrate_entry
+from custom_components.bsh_tides.legacy_migration import _seo_id_from_unique_id
+from custom_components.bsh_tides.bsh_api import BshApi
+from custom_components.bsh_tides.const import DOMAIN
+
+
+# --- helpers / fakes ------------------------------------------------------- #
+
+
+class _Entity:
+    def __init__(self, unique_id):
+        self.unique_id = unique_id
+
+
+class _Device:
+    def __init__(self, identifiers):
+        self.id = "dev-1"
+        self.identifiers = identifiers
+
+
+class _DeviceRegistry:
+    def __init__(self, device=None):
+        self._device = device
+        self.updated = []  # list of (device_id, new_identifiers)
+
+    def async_get_device(self, identifiers):
+        if self._device and self._device.identifiers == identifiers:
+            return self._device
+        return None
+
+    def async_update_device(self, device_id, new_identifiers):
+        self.updated.append((device_id, new_identifiers))
+
+
+class _ConfigEntries:
+    def __init__(self):
+        self.updates = []
+
+    def async_update_entry(self, entry, data=None, version=None):
+        self.updates.append((data, version))
+        if data is not None:
+            entry.data = data
+        if version is not None:
+            entry.version = version
+
+
+class _Hass:
+    def __init__(self):
+        self.config_entries = _ConfigEntries()
+
+
+class _Entry:
+    def __init__(self, bshnr, title, version=1, entry_id="entry-1"):
+        self.version = version
+        self.data = {"bshnr": bshnr}
+        self.title = title
+        self.entry_id = entry_id
+
+
+@pytest.fixture
+def patch_registries(monkeypatch):
+    """Patch entity/device registry access; returns a configurator."""
+
+    state = {"entities": [], "dev_reg": _DeviceRegistry()}
+
+    monkeypatch.setattr(migration.er, "async_get", lambda hass: object())
+    monkeypatch.setattr(
+        migration.er,
+        "async_entries_for_config_entry",
+        lambda reg, entry_id: state["entities"],
+    )
+    monkeypatch.setattr(migration.dr, "async_get", lambda hass: state["dev_reg"])
+
+    return state
+
+
+def _no_network(monkeypatch):
+    """Make any attempt to hit the live station list fail loudly."""
+
+    async def _boom():
+        raise AssertionError("network must not be used for this path")
+
+    monkeypatch.setattr(BshApi, "fetch_station_list", staticmethod(_boom))
+
+
+# --- _seo_id_from_unique_id ------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "unique_id,expected",
+    [
+        ("bsh_norderney_riffgat_next_high_tide_time", "norderney_riffgat"),
+        ("bsh_hamburg_st-pauli_mean_high_water_level", "hamburg_st-pauli"),
+        ("bsh_bremerhaven_alter_leuchtturm_forecast_type", "bremerhaven_alter_leuchtturm"),
+        ("bsh_flensburg_station_area", "flensburg"),
+        ("bsh_flensburg_next_tide_event", "flensburg"),
+        ("garbage", None),
+        ("bsh_flensburg_unknown_suffix", None),
+        (None, None),
+    ],
+)
+def test_seo_id_from_unique_id(unique_id, expected):
+    assert _seo_id_from_unique_id(unique_id) == expected
+
+
+# --- async_migrate_entry --------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_already_v2_is_noop(patch_registries):
+    hass = _Hass()
+    entry = _Entry("norderney_riffgat", "Norderney, Riffgat", version=2)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert hass.config_entries.updates == []  # nothing changed
+
+
+@pytest.mark.asyncio
+async def test_migrate_via_entity_registry_offline(patch_registries, monkeypatch):
+    """Slug recovered from existing entities; no network, rename-proof."""
+    _no_network(monkeypatch)
+    patch_registries["entities"] = [
+        _Entity("bsh_norderney_riffgat_next_high_tide_time")
+    ]
+    hass = _Hass()
+    # Title intentionally does NOT match (simulates a renamed entry).
+    entry = _Entry("111P", "My Renamed Station")
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 2
+    assert entry.data["bshnr"] == "norderney_riffgat"
+
+
+@pytest.mark.asyncio
+async def test_migrate_via_static_map_offline(patch_registries, monkeypatch):
+    """No entities, but the old bshnr is in the static table; no network."""
+    _no_network(monkeypatch)
+    patch_registries["entities"] = []
+    # Device exists under the old identifier -> must be re-pointed.
+    patch_registries["dev_reg"] = _DeviceRegistry(_Device({(DOMAIN, "111P")}))
+    hass = _Hass()
+    entry = _Entry("111P", "Norderney, Riffgat")
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.data["bshnr"] == "norderney_riffgat"
+    assert entry.version == 2
+    # device identifier was migrated in place
+    assert patch_registries["dev_reg"].updated == [
+        ("dev-1", {(DOMAIN, "norderney_riffgat")})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_migrate_via_name_match(patch_registries, monkeypatch):
+    """Unknown bshnr + no entities -> fall back to live name matching."""
+    patch_registries["entities"] = []
+
+    async def fake_list():
+        return [("some_station", "Some Station", "Elbe")]
+
+    monkeypatch.setattr(BshApi, "fetch_station_list", staticmethod(fake_list))
+
+    hass = _Hass()
+    entry = _Entry("999Z", "Some Station")
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.data["bshnr"] == "some_station"
+    assert entry.version == 2
+
+
+@pytest.mark.asyncio
+async def test_migrate_deferred_when_list_unavailable(patch_registries, monkeypatch):
+    """Transient network failure on the last-resort path -> retry later."""
+    patch_registries["entities"] = []
+
+    async def boom():
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(BshApi, "fetch_station_list", staticmethod(boom))
+
+    hass = _Hass()
+    entry = _Entry("999Z", "Unknown Station")
+
+    assert await async_migrate_entry(hass, entry) is False
+    assert entry.version == 1  # untouched
+    assert hass.config_entries.updates == []
+
+
+@pytest.mark.asyncio
+async def test_migrate_fails_when_unresolvable(patch_registries, monkeypatch):
+    """No entity, not in map, no name/slug match -> hard failure."""
+    patch_registries["entities"] = []
+
+    async def fake_list():
+        return [("other", "Other", "Elbe")]
+
+    monkeypatch.setattr(BshApi, "fetch_station_list", staticmethod(fake_list))
+
+    hass = _Hass()
+    entry = _Entry("999Z", "Nonexistent")
+
+    assert await async_migrate_entry(hass, entry) is False
+    assert entry.version == 1
+    assert hass.config_entries.updates == []


### PR DESCRIPTION
## Why

The old undocumented endpoint at `wasserstand-nordsee.bsh.de` was retired on **2026-05-27** (it now 301-redirects to `wasserstand.bsh.de`; `data/*.json` is gone), which broke all data fetches for every user (#5). The BSH replaced it with an **official, documented OGC API Features service** at `gdi.bsh.de` (ldproxy, **CC BY 4.0**) — a strict upgrade that additionally covers the Baltic Sea (135 stations vs. 82).

This PR switches the integration to the new API, keeps the sensors/entity IDs/history intact, and migrates existing config entries automatically.

## What — three commits

1. **Migrate to official gdi.bsh.de OGC API (adopt fork)** — faithful port of @svenblum's `fix/gdi-api-migration` fork. A new `bsh_api.py` talks to the OGC API and translates each station `Feature` back into the legacy flat dict via `feature_to_legacy()`, so `coordinator.py`/`sensor.py` stay unchanged. Config-flow `VERSION` 1→2; manifest 0.1.0.
2. **Harden v1→v2 migration, isolate it, finalize the switch** — resolve the new slug deterministically (existing entity `unique_id`s → static `bshnr→slug` table → live name match) and re-point the device identifier, so history/automations and device customisations survive. The one-time migration lives in a self-contained, deletable `legacy_migration` package. Re-enables strict TLS validation (the new cert validates cleanly). Refreshes the README/DISCLAIMER (official CC BY 4.0 API, North Sea + Baltic). Adds tests for `feature_to_legacy` and every migration branch.
3. **Devcontainer tooling + project Claude settings** — local-env only; reviewers can skip this commit.

## Verification

- **Against the live API + an archived copy of the old one:** old `seo_id` == new slug for **82/82** prior stations (entity `unique_id`s unchanged), and the peak (`high_water_low_water`) and curve-fallback (`automated_curve_forecast`) field mappings confirmed.
- **Tests:** 34 → **55 passing**.
- **Manual, in an HA-from-`dev` devcontainer:** fresh install + config flow works end-to-end; a simulated **v1→v2 migration** keeps entity history, preserves the device, and logs `Migrated BSH station … -> slug …`.

## Notes

- The `legacy_migration` package is intentionally throwaway; its docstring documents when to delete it (~mid-2027, once no pre-v2 entries remain).
- Suggested rollout: cut a GitHub **pre-release** first so beta-opted HACS users can run it before it becomes the default.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)